### PR TITLE
Rp initiated logout

### DIFF
--- a/src/Build/CommonAssemblyInfo.cs
+++ b/src/Build/CommonAssemblyInfo.cs
@@ -11,4 +11,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.5.0")]
+[assembly: AssemblyFileVersion("3.0.6.0")]

--- a/src/Keycloak.IdentityModel/KeycloakIdentity.cs
+++ b/src/Keycloak.IdentityModel/KeycloakIdentity.cs
@@ -329,14 +329,15 @@ namespace Keycloak.IdentityModel
         /// <param name="redirectUrl"></param>
         /// <returns></returns>
         public static async Task<Uri> GenerateLogoutUriAsync(IKeycloakParameters parameters, Uri baseUri,
-            string redirectUrl = null)
+            string redirectUrl = null, string idtoken = null)
         {
             if (parameters == null) throw new ArgumentNullException(nameof(parameters));
             if (baseUri == null) throw new ArgumentNullException(nameof(baseUri));
 
             // Generate logout URI and data
             var uriManager = await OidcDataManager.GetCachedContextAsync(parameters);
-            var logoutParams = uriManager.BuildEndSessionEndpointContent(baseUri, null, redirectUrl);
+            //As of KC v.18.0.0 the redirect_uri is obsolete. Use post_logout_redirect_uri with the id_token_hint to procceed to full logout. Otherwise user must confirm the logout
+            var logoutParams = uriManager.BuildEndSessionEndpointContent(baseUri, idtoken, redirectUrl);
             var logoutUrl = uriManager.GetEndSessionEndpoint();
 
             // Return logout URI

--- a/src/Keycloak.IdentityModel/Models/Messages/GenericMessage.cs
+++ b/src/Keycloak.IdentityModel/Models/Messages/GenericMessage.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Security.Authentication;
 using System.Threading.Tasks;
 using Keycloak.IdentityModel.Models.Configuration;
+using Keycloak.IdentityModel.Models.Responses;
 
 namespace Keycloak.IdentityModel.Models.Messages
 {
@@ -34,17 +35,7 @@ namespace Keycloak.IdentityModel.Models.Messages
                 throw new Exception("HTTP client URI is inaccessible", exception);
             }
 
-            // Check for HTTP errors
-            if (response.StatusCode == HttpStatusCode.BadRequest) {
-                _logger.Error($"HTTP client response returned error {response.ReasonPhrase}/{(int)response.StatusCode}.");
-                throw new AuthenticationException(); // Assume bad credentials
-            }
-
-            //if (!response.IsSuccessStatusCode)
-            //{
-            //    _logger.Error($"HTTP client response error {response.ReasonPhrase}/{response.StatusCode}.");
-            //    throw new Exception("HTTP client returned an unrecoverable error");
-            //}
+            
             return response;
         }
 
@@ -53,9 +44,19 @@ namespace Keycloak.IdentityModel.Models.Messages
             var result = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode)
             {
-                _logger.Error($"HTTP client response returned error {result}.");
+                _logger.Error($"HTTP client response returned error {result} : {response.ReasonPhrase}/{(int)response.StatusCode} .");
+                ErrorResponse errorResponse = new ErrorResponse(result);
+
+                // Check for HTTP errors
+                if (response.StatusCode == HttpStatusCode.Unauthorized 
+                    || (response.StatusCode == HttpStatusCode.BadRequest & errorResponse.Error.Equals("invalid_grant")))
+                {
+                    throw new AuthenticationException();
+                }
+
                 throw new Exception("HTTP client returned an unrecoverable error");
             }
+           
             return result;
         }
 

--- a/src/Keycloak.IdentityModel/Models/Responses/TokenResponse.cs
+++ b/src/Keycloak.IdentityModel/Models/Responses/TokenResponse.cs
@@ -48,4 +48,22 @@ namespace Keycloak.IdentityModel.Models.Responses
             RefreshToken = authResult.Get(Constants.OpenIdConnectParameterNames.RefreshToken);
         }
     }
+
+    public class ErrorResponse : OidcResponse
+    {
+        public ErrorResponse(string encodedJson)
+            : this(JObject.Parse(encodedJson))
+        {
+        }
+        public ErrorResponse(JObject json)
+        {
+            var authResult = new NameValueCollection();
+
+            // Convert JSON to NameValueCollection type
+            foreach (var item in json)
+                authResult.Add(item.Key, item.Value.ToString());
+
+            base.InitFromRequest(authResult);
+        }
+    }
 }

--- a/src/Keycloak.IdentityModel/Utilities/OidcDataManager.cs
+++ b/src/Keycloak.IdentityModel/Utilities/OidcDataManager.cs
@@ -401,11 +401,11 @@ namespace Keycloak.IdentityModel.Utilities
             if (string.IsNullOrEmpty(postLogoutRedirectUrl)) // Double-check options for empty/null
                 postLogoutRedirectUrl = requestUri.GetLeftPart(UriPartial.Authority);
             else if (Uri.IsWellFormedUriString(postLogoutRedirectUrl, UriKind.Relative))
-                postLogoutRedirectUrl = requestUri.GetLeftPart(UriPartial.Authority) + "/" + postLogoutRedirectUrl;
+                postLogoutRedirectUrl = requestUri.GetLeftPart(UriPartial.Authority) + "/" + postLogoutRedirectUrl.TrimStart('/','~');
 
             if (!Uri.IsWellFormedUriString(postLogoutRedirectUrl, UriKind.RelativeOrAbsolute))
                 throw new Exception("Invalid PostLogoutRedirectUrl option: Not a valid relative/absolute URL");
-
+            
             parameters.Add(Protocols.OpenIdConnectParameterNames.PostLogoutRedirectUri, postLogoutRedirectUrl);
 
             return new FormUrlEncodedContent(parameters);

--- a/src/Owin.Security.Keycloak/Middleware/KeycloakAuthenticationHandler.cs
+++ b/src/Owin.Security.Keycloak/Middleware/KeycloakAuthenticationHandler.cs
@@ -159,6 +159,7 @@ namespace Owin.Security.Keycloak.Middleware
                 }
 
                 var challenge = Helper.LookupChallenge(Options.AuthenticationType, Options.AuthenticationMode);
+                
                 if (challenge == null) return;
 
                 _logger.Debug($"ApplyResponseChallengeAsync for 401.Redirecting");
@@ -171,7 +172,9 @@ namespace Owin.Security.Keycloak.Middleware
         private void SignInAsAuthentication(ClaimsIdentity identity, AuthenticationProperties authProperties = null,
             string signInAuthType = null)
         {
-            if (signInAuthType == Options.AuthenticationType) return;
+            // adding commit 17b4dd6e7ea700686581f62a808037b787f0861c that was missing
+            if (!string.IsNullOrWhiteSpace(signInAuthType) && !signInAuthType.Equals(Options.AuthenticationType, StringComparison.OrdinalIgnoreCase)) return;
+
 
             var signInIdentity = signInAuthType != null
                 ? new ClaimsIdentity(identity.Claims, signInAuthType, identity.NameClaimType, identity.RoleClaimType)

--- a/src/Owin.Security.Keycloak/Middleware/KeycloakAuthenticationHandler.cs
+++ b/src/Owin.Security.Keycloak/Middleware/KeycloakAuthenticationHandler.cs
@@ -143,7 +143,7 @@ namespace Owin.Security.Keycloak.Middleware
             // Signout takes precedence
             if (signout != null)
             {
-                await LogoutRedirectAsync();
+                await LogoutRedirectAsync(signout.Properties);
             }
         }
 
@@ -334,14 +334,14 @@ namespace Owin.Security.Keycloak.Middleware
             Response.Redirect((await KeycloakIdentity.GenerateLoginUriAsync(Options, Request.Uri, state)).ToString());
         }
 
-        private async Task LogoutRedirectAsync()
+        private async Task LogoutRedirectAsync(AuthenticationProperties properties)
         {
 
             string idToken = Context.Authentication.User.Claims?.FirstOrDefault(c => c.Type == Constants.ClaimTypes.IdToken)?.Value;
             // Redirect response to logout
             Response.Redirect(
                 (await
-                    KeycloakIdentity.GenerateLogoutUriAsync(Options, Request.Uri, null, idToken))
+                    KeycloakIdentity.GenerateLogoutUriAsync(Options, Request.Uri, properties.RedirectUri, idToken))
                     .ToString());
         }
 

--- a/src/Owin.Security.Keycloak/Middleware/KeycloakAuthenticationHandler.cs
+++ b/src/Owin.Security.Keycloak/Middleware/KeycloakAuthenticationHandler.cs
@@ -6,8 +6,10 @@ using System.IdentityModel;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.Remoting.Contexts;
 using System.Security.Authentication;
 using System.Security.Claims;
+using System.Security.Principal;
 using System.Threading.Tasks;
 using Keycloak.IdentityModel;
 using Keycloak.IdentityModel.Models.EventArgs;
@@ -172,7 +174,7 @@ namespace Owin.Security.Keycloak.Middleware
         private void SignInAsAuthentication(ClaimsIdentity identity, AuthenticationProperties authProperties = null,
             string signInAuthType = null)
         {
-            // adding commit 17b4dd6e7ea700686581f62a808037b787f0861c that was missing
+            // adding missing change from commit 17b4dd6e7ea700686581f62a808037b787f0861c 
             if (!string.IsNullOrWhiteSpace(signInAuthType) && !signInAuthType.Equals(Options.AuthenticationType, StringComparison.OrdinalIgnoreCase)) return;
 
 
@@ -334,10 +336,12 @@ namespace Owin.Security.Keycloak.Middleware
 
         private async Task LogoutRedirectAsync()
         {
+
+            string idToken = Context.Authentication.User.Claims?.FirstOrDefault(c => c.Type == Constants.ClaimTypes.IdToken)?.Value;
             // Redirect response to logout
             Response.Redirect(
                 (await
-                    KeycloakIdentity.GenerateLogoutUriAsync(Options, Request.Uri))
+                    KeycloakIdentity.GenerateLogoutUriAsync(Options, Request.Uri, null, idToken))
                     .ToString());
         }
 
@@ -350,7 +354,8 @@ namespace Owin.Security.Keycloak.Middleware
         private async Task ForceLogoutRedirectAsync(ClaimsIdentity identity)
         {
             // generate logout uri
-            var uri = await KeycloakIdentity.GenerateLogoutUriAsync(Options, Request.Uri);
+            string idtoken = identity.Claims?.FirstOrDefault(c => c.Type == Constants.ClaimTypes.IdToken)?.Value;
+            var uri = await KeycloakIdentity.GenerateLogoutUriAsync(Options, Request.Uri, null, idtoken);
             //foreach (var claim in identity.Claims)
             //{
             //    _logger.Debug($"ForceLogoutRedirectAsync user claim {claim.Type} - {claim.Value}");

--- a/src/SampleWebApp/Controllers/HomeController.cs
+++ b/src/SampleWebApp/Controllers/HomeController.cs
@@ -1,6 +1,9 @@
-﻿using System;
+﻿using Microsoft.Owin.Security;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
 
@@ -10,22 +13,50 @@ namespace SampleWebApp.Controllers
 	{
 		public ActionResult Index()
 		{
-			return View();
+            bool isAuthenticated = HttpContext.GetOwinContext().Authentication.User != null ? HttpContext.GetOwinContext().Authentication.User.Identity.IsAuthenticated : false;
+            ViewBag.IsAuthenticated = isAuthenticated;
+            return View();
 		}
 
 		[Authorize]
 		public ActionResult About()
 		{
-			ViewBag.Message = "Your application description page.";
+            ViewBag.Message = "Your application description page.";
 
 			return View();
 		}
 
 		public ActionResult Contact()
 		{
-			ViewBag.Message = "Your contact page.";
+            ViewBag.Message = "Your contact page.";
 
 			return View();
 		}
-	}
+
+		public ActionResult Callback() {
+
+            //do whatever your app requires or delete this method
+            return RedirectToAction("Index");
+        }
+
+        public ActionResult Error(string error)
+        {
+            ViewBag.Error = error;
+            return View();
+        }
+
+        [Authorize]
+        public ActionResult Logout()
+        {
+
+            bool isAuthenticated = HttpContext.GetOwinContext().Authentication.User.Identity.IsAuthenticated;
+            HttpContext.GetOwinContext().Authentication.SignOut();
+            return RedirectToAction("Index");
+        }
+
+        public void LoggedOut()
+        {
+            bool isAuthenticated = HttpContext.GetOwinContext().Authentication.User.Identity.IsAuthenticated;
+        }
+    }
 }

--- a/src/SampleWebApp/Global.asax.cs
+++ b/src/SampleWebApp/Global.asax.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Web;
 using System.Web.Mvc;
@@ -16,6 +17,9 @@ namespace SampleWebApp
 			FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
 			RouteConfig.RegisterRoutes(RouteTable.Routes);
 			BundleConfig.RegisterBundles(BundleTable.Bundles);
-		}
-	}
+
+            log4net.Config.XmlConfigurator.Configure(new FileInfo(Server.MapPath("~/Web.config")));
+
+        }
+    }
 }

--- a/src/SampleWebApp/SampleWebApp.csproj
+++ b/src/SampleWebApp/SampleWebApp.csproj
@@ -25,6 +25,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -47,6 +48,9 @@
   <ItemGroup>
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>

--- a/src/SampleWebApp/Startup.cs
+++ b/src/SampleWebApp/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.Owin.Security.Cookies;
 using Owin;
 using Owin.Security.Keycloak;
 using System;
+using static System.Net.WebRequestMethods;
 
 [assembly: OwinStartup(typeof(SampleWebApp.Startup))]
 namespace SampleWebApp
@@ -24,27 +25,49 @@ namespace SampleWebApp
 
 			app.UseKeycloakAuthentication(new KeycloakAuthenticationOptions
 			{
-				Realm = "ajboggs",
-				ClientId = "sample-web-app",
-				ClientSecret = "8eb92690-8c0c-42ba-b1ac-106dd2d06a22",
-				KeycloakUrl = "https://titanoboa.ajboggs.com/auth",
-				//ResponseType = "id_token token",
+				Realm = "Athena",
+				ClientId = "athena-portal",
+				ClientSecret = "qAAtPWNLR1mVMJTizFf0ZQ6wsdcnGPoI",
+				KeycloakUrl = "http://localhost:8080/",
+				ResponseType = "code",
 				AuthenticationType = persistentAuthType,
 				//AuthenticationMode = AuthenticationMode.Active,
 				SignInAsAuthenticationType = persistentAuthType, // Not required with SetDefaultSignInAsAuthenticationType
-																												 //Token validation options - these are all set to defaults
+				//Token validation options - these are all set to defaults
 				AllowUnsignedTokens = false,
 				DisableTokenSignatureValidation = false,
-				DisableIssuerValidation = false,
+                DisableIssuerValidation = false,
 				DisableAudienceValidation = false,
+                //CallbackPath = "/Home/Callback",
+               // PostLogoutRedirectUrl = "http://localhost:5232/Home/LoggedOut",
 
-				// DisableRefreshTokenSignatureValidation = true, // Fix for Keycloak server v4.5
-				// DisableAllRefreshTokenValidation = true, // Fix for Keycloak server v4.6-4.8,  overrides DisableRefreshTokenSignatureValidation. The content of Refresh token was changed. Refresh token should not be used by the client application other than sending it to the Keycloak server to get a new Access token (where Keycloak server will validate it) - therefore validation in client application can be skipped.
+                DisableRefreshTokenSignatureValidation = true,
+                // , // Fix for Keycloak server v4.5
+                DisableAllRefreshTokenValidation = true, // Fix for Keycloak server v4.6-4.8,  overrides DisableRefreshTokenSignatureValidation. The content of Refresh token was changed. Refresh token should not be used by the client application other than sending it to the Keycloak server to get a new Access token (where Keycloak server will validate it) - therefore validation in client application can be skipped.
 
-				// AuthResponseErrorRedirectUrl = "/keycloak-authenticaion-error.html", //Redirect (instead of exception) when Keycloak returns error during authentication. Will include "error" query parameter.
+                AuthResponseErrorRedirectUrl = "/Home/Error", //Redirect (instead of exception) when Keycloak returns error during authentication. Will include "error" query parameter.
 
-				TokenClockSkew = TimeSpan.FromSeconds(2)
+                TokenClockSkew = TimeSpan.FromSeconds(2)
 			});
-		}
-	}
+            //app.UseKeycloakAuthentication(new KeycloakAuthenticationOptions
+            //{
+            //    // App-Specific Settings
+             
+            //    AllowUnsignedTokens = false,
+            //    DisableIssuerValidation = false,
+            //    DisableAudienceValidation = false,
+            //    //PostLogoutRedirectUrl = "http://localhost:5252/",//ConfigurationManager.AppSettings["authCookie"],
+            //    TokenClockSkew = TimeSpan.FromSeconds(2), // System.TimeZoneInfo.Local.GetUtcOffset(System.DateTime.UtcNow), //The time subtracted from the final access token expiration time//The maximum grace time span for expired tokens to be accepted
+            //    //OnAuthenticated = delegate (IOwinContext con, OnAuthenticatedEventArgs args)
+            //    //{
+            //    //    AssignAuthorizationRedirectUri(con, args);
+            //    //},
+            //    RefreshBeforeTokenExpiration = TimeSpan.FromSeconds(30),
+            //    // validation of refresh token is done on the server side anyways
+            //    // Fix for Keycloak server v4.6-4.8,  overrides DisableRefreshTokenSignatureValidation. The content of Refresh token was changed. Refresh token should not be used by the client application other than sending it to the Keycloak server to get a new Access token (where Keycloak server will validate it) - therefore validation in client application can be skipped
+            //    DisableAllRefreshTokenValidation = true
+            //});
+
+        }
+    }
 }

--- a/src/SampleWebApp/Views/Home/About.cshtml
+++ b/src/SampleWebApp/Views/Home/About.cshtml
@@ -1,7 +1,20 @@
-﻿@{
+﻿@model System.Security.Claims.ClaimsPrincipal
+@using System.Security.Claims
+@{
     ViewBag.Title = "About";
 }
 <h2>@ViewBag.Title.</h2>
 <h3>@ViewBag.Message</h3>
 
 <p>Use this area to provide additional information.</p>
+@if (HttpContext.Current.GetOwinContext().Authentication.User != null)
+{
+    <ul>
+        @foreach (var claim in HttpContext.Current.GetOwinContext().Authentication.User.Claims)
+        {
+        <li>
+            @claim.Type : @claim.Value
+        </li>
+        }
+    </ul>
+}

--- a/src/SampleWebApp/Views/Home/Index.cshtml
+++ b/src/SampleWebApp/Views/Home/Index.cshtml
@@ -29,3 +29,8 @@
         <p><a class="btn btn-default" href="https://go.microsoft.com/fwlink/?LinkId=301867">Learn more &raquo;</a></p>
     </div>
 </div>
+
+@if (ViewBag.IsAuthenticated != null)
+{<div class="row">
+        <div class="col-md-12"><h3>Authenticate through the About page. </h3> Currently user is @( ViewBag.IsAuthenticated ? "" : "not") authenticated. </div>
+    </div>}

--- a/src/SampleWebApp/Views/Shared/Error.cshtml
+++ b/src/SampleWebApp/Views/Shared/Error.cshtml
@@ -9,5 +9,6 @@
         <h1>Error.</h1>
         <h2>An error occurred while processing your request.</h2>
     </hgroup>
+    @ViewBag.Error
 </body>
 </html>

--- a/src/SampleWebApp/Views/Shared/_Layout.cshtml
+++ b/src/SampleWebApp/Views/Shared/_Layout.cshtml
@@ -23,6 +23,7 @@
                     <li>@Html.ActionLink("Home", "Index", "Home")</li>
                     <li>@Html.ActionLink("About", "About", "Home")</li>
                     <li>@Html.ActionLink("Contact", "Contact", "Home")</li>
+                    <li>@Html.ActionLink("Disconnect", "Logout", "Home")</li>
                 </ul>
             </div>
         </div>

--- a/src/SampleWebApp/Views/Web.config
+++ b/src/SampleWebApp/Views/Web.config
@@ -24,7 +24,8 @@
 
   <appSettings>
     <add key="webpages:Enabled" value="false" />
-  </appSettings>
+	  <add key="webpages:Version" value="3.0.0.0"/>
+	</appSettings>
 
   <system.webServer>
     <handlers>

--- a/src/SampleWebApp/Web.config
+++ b/src/SampleWebApp/Web.config
@@ -4,12 +4,34 @@
   https://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
-  <appSettings>
-    <add key="webpages:Version" value="3.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-  </appSettings>
+	<configSections>
+		<section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
+	</configSections>
+	<appSettings>
+        <add key="webpages:Version" value="3.0.0.0" />
+        <add key="webpages:Enabled" value="false" />
+        <add key="ClientValidationEnabled" value="true" />
+        <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+      </appSettings>
+	<log4net debug="true">
+		<appender name="RollingLogFileAppender" type="log4net.Appender.RollingFileAppender">
+			<lockingModel type="log4net.Appender.FileAppender+MinimalLock"/>
+			<file value="..\..\..\logs\KeycloakOwinLog"/>
+			<appendToFile value="true"/>
+			<encoding value="utf-8"/>
+			<rollingStyle value="Date"/>
+			<datePattern value="_yyyyMMdd'.txt'"/>
+			<staticLogFileName value="false"/>
+			<maximumFileSize value="10MB"/>
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%date [%thread] %-5level %logger %m%n"/>
+			</layout>
+		</appender>
+		<root>
+			<level value="DEBUG"/>
+			<appender-ref ref="RollingLogFileAppender"/>
+		</root>
+	</log4net>
   <system.web>
     <compilation debug="true" targetFramework="4.6.2" />
     <httpRuntime targetFramework="4.6.2" />

--- a/src/SampleWebApp/packages.config
+++ b/src/SampleWebApp/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+	<package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Antlr" version="3.5.0.2" targetFramework="net462" />
   <package id="bootstrap" version="3.3.7" targetFramework="net462" />
   <package id="jQuery" version="3.1.1" targetFramework="net462" />


### PR DESCRIPTION
The logout process now takes into consideration the id_token_hint as suggested by RP-initiated logout (and used in latest KC 26.2). Also the authentication properties are passed in the logout process to redirect the user to any redirect url provided by the client (aside from the options post logout redirect url).