### PR TITLE
authorization url sets request's lang parameter to ui_locales

### DIFF
--- a/src/Keycloak.IdentityModel/Constants.cs
+++ b/src/Keycloak.IdentityModel/Constants.cs
@@ -3,8 +3,9 @@
 	public static class Constants
 	{
 		public const string BearerTokenHeader = "Authorization";
+        public const string RequestLanguage = "lang";
 
-		public static class ClaimTypes
+        public static class ClaimTypes
 		{
 			public const string IdToken = "id_token";
 			public const string AccessToken = "access_token";

--- a/src/Keycloak.IdentityModel/Properties/AssemblyInfo.cs
+++ b/src/Keycloak.IdentityModel/Properties/AssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
+[assembly: AssemblyInformationalVersion("2.1.0.0")]

--- a/src/Keycloak.IdentityModel/Utilities/OidcDataManager.cs
+++ b/src/Keycloak.IdentityModel/Utilities/OidcDataManager.cs
@@ -1,15 +1,17 @@
-﻿using System;
+﻿using Keycloak.IdentityModel.Models.Configuration;
+using Keycloak.IdentityModel.Utilities.Synchronization;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Keycloak.IdentityModel.Models.Configuration;
-using Keycloak.IdentityModel.Utilities.Synchronization;
+using System.Web;
 using Protocols = Microsoft.IdentityModel.Protocols;
-using Microsoft.IdentityModel.Tokens;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Keycloak.IdentityModel.Utilities
 {
@@ -334,7 +336,13 @@ namespace Keycloak.IdentityModel.Utilities
             if (!string.IsNullOrWhiteSpace(_options.IdentityProvider))
                 parameters.Add(Constants.KeycloakParameters.IdpHint, _options.IdentityProvider);
 
-            if (!string.IsNullOrWhiteSpace(_options.UiLocales))
+            //respect request's user language if specified, otherwise use options
+            if (!string.IsNullOrWhiteSpace(requestUri.Query))
+            {
+                string uriLang = HttpUtility.ParseQueryString(requestUri.Query)?.Get(Constants.RequestLanguage);
+                if(!string.IsNullOrWhiteSpace(uriLang))
+                    parameters.Add(Protocols.OpenIdConnectParameterNames.UiLocales, uriLang);
+            } else if (!string.IsNullOrWhiteSpace(_options.UiLocales))
                 parameters.Add(Protocols.OpenIdConnectParameterNames.UiLocales, _options.UiLocales);
 
             return new FormUrlEncodedContent(parameters);


### PR DESCRIPTION
When buidling the authorization endpoint to IDM if there is an Options.UILocales it is applied to it. However, this Options parameter cannot reflect the user's selected language from the application's point of view. So if the lang query parameter exists in the request uri, it has priority over Options.UILocales